### PR TITLE
Fix owner to /app/ in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ In order to replace the "Hello World" application that comes bundled with this d
     FROM tutum/nginx
     ADD sites-enabled/ /etc/nginx/sites-enabled/
     ADD app/ /app/
+    RUN chown -R www-data:www-data /app/
     EXPOSE 80
 
 Remember to put your configuration files under the folder named `sites-enabled` and your website files under the folder `app`. Also, if you want to use a different port, change the `EXPOSE 80` in `Dockerfile` as well.(eg. `EXPOSE 443 80` will allow connections go through port `443` and `80`).


### PR DESCRIPTION
Running with docker compose, nginx returning 403 when /app/ was of root!
